### PR TITLE
DOCUMENT_ROOT may not end with a slash

### DIFF
--- a/src/sixtus/conversion_php.py
+++ b/src/sixtus/conversion_php.py
@@ -174,7 +174,7 @@ class PHPFull(Full):
 		if 'tabself' in self.meta: output += '"%s"' % self.meta['tabself']
 		else: output += 'false'
 		output += ');'
-		output += '$sixtus=$_SERVER["DOCUMENT_ROOT"]."sixtus/";'
+		output += '$sixtus=$_SERVER["DOCUMENT_ROOT"]."/sixtus/";'
 		output += 'require_once($sixtus."page-top.php");}if($i[1]){?>'
 		output += '\n%s\n' % self.page
 		output += '<?php }if($i[0])require_once($sixtus."page-middle.php");'


### PR DESCRIPTION
There is no guarantee that `DOCUMENT_ROOT` ends with a slash:
if that's not the case, the `$sixtus` variable may end up being
set to something like `/var/wwwsixtus` rather than the expected
`/var/www/sixtus`, and subsequent calls to `require_once()` will
fail because the path doesn't exist.

Always add a slash after `DOCUMENT_ROOT` to avoid the issue.